### PR TITLE
added content type for a secondary banner for inner pages

### DIFF
--- a/api/page/models/page.settings.json
+++ b/api/page/models/page.settings.json
@@ -32,6 +32,11 @@
       "type": "boolean",
       "default": true,
       "required": true
+    },
+    "secondary_banner": {
+      "type": "component",
+      "repeatable": false,
+      "component": "general.inner-page-secondary-banner"
     }
   }
 }

--- a/components/general/inner-page-secondary-banner.json
+++ b/components/general/inner-page-secondary-banner.json
@@ -1,0 +1,19 @@
+{
+  "collectionName": "components_general_inner_page_secondary_banners",
+  "info": {
+    "name": "InnerPageSecondaryBanner",
+    "icon": "address-book"
+  },
+  "options": {},
+  "attributes": {
+    "description": {
+      "type": "string",
+      "required": true
+    },
+    "banner_button": {
+      "type": "component",
+      "repeatable": false,
+      "component": "general.link"
+    }
+  }
+}


### PR DESCRIPTION
### Changes 

- created a new component named `InnerPageSecondaryBanner`
- Added the required fields for the component.
- Added the component to the `page` content type.